### PR TITLE
Jython compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -393,3 +393,6 @@ $RECYCLE.BIN/
 BappModules
 ext/
 inql/__version__.py
+
+# Jython
+.jython*

--- a/inql/introspection.py
+++ b/inql/introspection.py
@@ -44,7 +44,9 @@ def wrap_exit(method, exceptions = (OSError, IOError)):
             sys.exit('Can\'t open \'{0}\'. Error #{1[0]}: {1[1]}'.format(args[0], sys.exc_info()[1].args))
 
     return fn
-exit = wrap_exit(exit)
+
+if sys.version_info[0] == 2:
+    exit = wrap_exit(exit)
 
 # colors for terminal messages
 red = ""
@@ -254,6 +256,7 @@ def init(args, print_help=None):
 
     if args.target is not None or args.schema_json_file is not None:
         if args.target is not None:
+            args.target = str(args.target)
             # Acquire GraphQL endpoint URL as a target
             host = urlparse(args.target).netloc
         else:

--- a/inql/widgets/payloadview.py
+++ b/inql/widgets/payloadview.py
@@ -32,19 +32,6 @@ class _PayloadListener(DocumentListener):
     def changedUpdate(self, e):
         self.changed_update(e)
 
-BaseTabbedPaneUI = JTabbedPane().getUI().getClass()
-
-class SneakTabbedPaneUI(BaseTabbedPaneUI):
-    def __init__(self, tabbed_pane):
-        self.tabbed_pane = tabbed_pane
-
-    def calculateTabAreaHeight(self, tab_placement, run_count, max_tab_height):
-        if self.tabbed_pane.getTabCount() > 1:
-            return self.super__calculateTabAreaHeight(tab_placement, run_count, max_tab_height)
-        else:
-            return 0
-
-
 class PayloadView:
     """
     PayloadView is a TextView viewer and editor.
@@ -59,7 +46,6 @@ class PayloadView:
         self._listener = None
 
         self.this = JTabbedPane()
-        self.this.setUI(SneakTabbedPaneUI(self.this))
 
         if payload:
             self.refresh(payload)


### PR DESCRIPTION
Fixes issues caused by Java / Jython bump.

The main change relates to Java encapsulating a few Mac OS specific APIs, which made introspection of these API's obsolete. This was indirectly used in an `SneakTabbedPaneUI` class, however it seems that the class isn't required at all.