### PR TITLE
Fix #48

### DIFF
--- a/inql/burp_ext/generator_tab.py
+++ b/inql/burp_ext/generator_tab.py
@@ -97,7 +97,7 @@ class GeneratorTab(ITab):
     def disable_http2_ifbogus(self):
         try:
             _, major, minor = self._callbacks.getBurpVersion()
-            if not (int(major) >= 2021 and int(minor) >= 8):
+            if not (int(major) >= 2021 and float(minor) >= 8):
                 print("Jython does not support HTTP/2 on Burp <= 2021.8: disabling it!")
                 j = json.loads(self._callbacks.saveConfigAsJson())
                 j['project_options']['http']['http2']['enable_http2'] = False


### PR DESCRIPTION
There is a small bug caused by Burp versions being floats not ints. Incorrect casting cause an exception, but it got masked by encompassing try/except.