### PR TITLE
Display Variables tab by default

### DIFF
--- a/inql/widgets/payloadview.py
+++ b/inql/widgets/payloadview.py
@@ -246,11 +246,10 @@ class PayloadView:
                     self.this.addTab(tname, this)
                     this.setOneTouchExpandable(True)
                     this.setDividerLocation(0.66)
+                    this.getBottomComponent().setVisible(True)
                     if 'variables' in queries[query_key]:
-                        this.getBottomComponent().setVisible(True)
                         self._textareas[vname].setText(json.dumps(queries[query_key]['variables'], indent=4))
                     else:
-                        this.getBottomComponent().setVisible(False)
                         self._textareas[vname].setText("{}")
 
         # Remove empty graphql tabs


### PR DESCRIPTION
Previously Variables tab got marked unvisible (`setVisible(False)`) if the request JSON didn't have any variables. This made the tab unoperable (even the "One touch" arrows don't work) and in order to add variables user needed to go back to raw/pretty tabs.

This change displays Variables tab by default which is convenient and confirms to the GraphiQL layout.