### PR TITLE
Add Points of Interest and Fast Cycles

### DIFF
--- a/inql/generators/fastcycles.py
+++ b/inql/generators/fastcycles.py
@@ -1,0 +1,41 @@
+from inql.generators.poi import Graph, Node
+from inql.utils import simplify_introspection
+from collections import defaultdict
+import re
+import json
+
+def generate(
+    argument,
+    fpath="fastcycles.txt",
+    streaming=False,
+    green_print=lambda s: print(s),
+):
+    """
+    Generate Report on Sensitive Field Names
+
+    :param argument: introspection query result
+    :param fpath: output result
+    :param streaming: boolean trigger to output to stdout or write to file with fpath
+    :return: None
+    """
+    green_print("Generating Fast Cycles")
+    # simplify schema
+    si = simplify_introspection(argument)
+    # all nodes will have a name and their corresponding object
+    graph = Graph(
+        schema={
+            v["type"]: Node(name=v["type"], ntype=k) for k, v in si["schema"].items()
+        },
+        data=si["type"],
+    )
+    graph.generate()
+
+    matrix,keys = graph.gen_matrix()
+    matrix.SCC()
+    cycles = matrix.format_cycles(list(keys))
+
+    if streaming:
+        print(cycles)
+    else:
+        with open(fpath, "w") as schema_file:
+            schema_file.write(cycles)

--- a/inql/generators/fastcycles.py
+++ b/inql/generators/fastcycles.py
@@ -34,6 +34,8 @@ def generate(
     matrix,keys = graph.gen_matrix()
     matrix.SCC()
     cycles = matrix.format_cycles(list(keys))
+    cycles_view = ',\n\t'.join(['->'.join(cycle) for cycle in cycles])
+    cycles = f"Cycles(\n\t{cycles_view}\n)"
 
     if streaming:
         print(cycles)

--- a/inql/generators/fastcycles.py
+++ b/inql/generators/fastcycles.py
@@ -27,6 +27,7 @@ def generate(
             v["type"]: Node(name=v["type"], ntype=k) for k, v in si["schema"].items()
         },
         data=si["type"],
+        types=list(si.get("enum",{}).keys()) + list(si.get("scalar",{}).keys())
     )
     graph.generate()
 

--- a/inql/generators/poi.py
+++ b/inql/generators/poi.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 import re
 import json
 
-GRAPHQL_BUILTINS = ["Int", "String", "ID", "Boolean", "Float"]
 DEFAULT_REGEX = "|".join(
     [
         r"pass",
@@ -25,11 +24,12 @@ DEFAULT_REGEX = "|".join(
 
 
 class Graph:
-    def __init__(self, nodes=None, data=None, schema=None, functions=None):
+    def __init__(self, nodes=None, data=None, schema=None, functions=None, types=None):
         self.nodes = nodes or {}
         self.schema = schema or {}
         self.functions = functions or {}
         self.data = data or {}
+        self.GRAPHQL_BUILTINS = ["Int", "String", "ID", "Boolean", "Float"] + (types or [])
 
     def node(self, node_name=None):
         if node_name:
@@ -60,7 +60,7 @@ class Graph:
                 for field_name, field_data in obj_data.items():
                     if field_name in ["__implements"]:
                         continue
-                    elif field_data["type"].startswith(tuple(GRAPHQL_BUILTINS)):
+                    elif field_data["type"].startswith(tuple(self.GRAPHQL_BUILTINS)):
                         field = field_data["type"]
                     else:
                         field = self.node(field_data["type"])
@@ -238,6 +238,7 @@ def generate(
             v["type"]: Node(name=v["type"], ntype=k) for k, v in si["schema"].items()
         },
         data=si["type"],
+        types=list(si.get("enum",{}).keys()) + list(si.get("scalar",{}).keys())
     )
     graph.generate()
 

--- a/inql/generators/poi.py
+++ b/inql/generators/poi.py
@@ -1,0 +1,66 @@
+from inql.utils import simplify_introspection
+GRAPHQL_BUILTINS = ["Int", "String", "ID", "Boolean", "Float"]
+class Graph:
+    def __init__(self,graph=None,data=None):
+        self.graph = graph or {}
+        self.data = data or {}
+    def get(self,node_name):
+        node = self.graph.get(node_name,False)
+        if node:
+            return node
+        else:
+            breakpoint()
+            self.data[node_name]
+            
+    def __str__(self):
+        return ""
+    def __repr__(self):
+        return ""
+class Node:
+    def __init__(self,name,ntype='',inputs=None,children=None,parents=None,raw=None):
+        self.name = name
+        self.ntype = ntype or "Object"
+        self.inputs = inputs or ...
+        self.children = children or {}
+        self.parents = parents or {}
+        self.raw = raw or {}
+    def add_child(self,field_name,child):
+        self.children[field_name] = child
+    def add_parent(self,parent):
+        self.parents[parent.name] = parent
+    def __str__(self):
+        return f"{self.ntype}(name={self.name})"
+    def __repr__(self):
+        return f"{self.ntype}(name={self.name})"
+    def __hash__(self):
+        return hash((self.name,self.ntype))
+    def __eq__(self,other):
+        return isinstance(other,Node) and (self.name,self.ntype) == (other.name,self.ntype)
+    def __ne__(self,other):
+        return not (self == other)
+
+
+def generate(argument, fpath="cycles.txt", green_print=lambda s: print(s)):
+    """
+    Generate Report on Sensitive Field Names
+
+    :param argument: introspection query result
+    :param fpath: output result
+    :return: None
+    """
+    green_print("Generating POI's")
+    # simplify schema
+    si = simplify_introspection(argument)
+    schema = [Node(name=v["type"],ntype=k) for k,v in si["schema"].items()]
+    # all nodes will have a name and their corresponding object
+    graph = Graph(data=si["type"])
+    # get high level function names and return types
+    for query in schema:
+        for func,data in si["type"].pop(query.name).items():
+            function_gqlo = Node(name=func,type="function",raw=data)
+
+            
+            function_gqlo.add_child(nodes[data["type"]])
+            query.add_child(function_gqlo)
+    
+    breakpoint()

--- a/inql/generators/poi.py
+++ b/inql/generators/poi.py
@@ -170,7 +170,12 @@ class Matrix:
         for cycle in self.cycles:
             if len(cycle) == 1:
                 continue
-            transformed.append([keys[idx] for idx in cycle[::-1]])
+            tmp = []
+            for idx in cycle[::-1]:
+                n = keys[idx]
+                rep = n if isinstance(n,str) else f"{n[0]}-[{n[1]}]"
+                tmp.append(rep)
+            transformed.append(tmp)
         return transformed
 
 

--- a/inql/generators/poi.py
+++ b/inql/generators/poi.py
@@ -1,42 +1,133 @@
 from inql.utils import simplify_introspection
+import re
+
 GRAPHQL_BUILTINS = ["Int", "String", "ID", "Boolean", "Float"]
+
+
 class Graph:
-    def __init__(self,graph=None,data=None):
-        self.graph = graph or {}
+    def __init__(self, nodes=None, data=None, schema=None, functions=None):
+        self.nodes = nodes or {}
+        self.schema = schema or {}
+        self.functions = functions or {}
         self.data = data or {}
-    def get(self,node_name):
-        node = self.graph.get(node_name,False)
-        if node:
+
+    def node(self, node_name=None):
+        if node_name:
+            node = self.nodes.get(node_name, Node(node_name))
+            self.nodes[node_name] = node
             return node
         else:
-            breakpoint()
-            self.data[node_name]
-            
+            return {k: v for k, v in self.nodes.items()}
+
+    def function(self, function_name=None):
+        if function_name:
+            node = self.functions.get(function_name, Node(function_name))
+            self.functions[function_name] = node
+            return node
+        else:
+            return {k: v for k, v in self.functions.items()}
+
+    def generate(self):
+        for obj_name, obj_data in self.data.items():
+            if obj_name in self.schema:
+                node = self.schema[obj_name]
+                for field_name, field_data in obj_data.items():
+                    field = self.function(field_data["type"])
+                    node.add_child(field_name, field)
+                    field.add_parent(node)
+            else:
+                node = self.node(obj_name)
+                for field_name, field_data in obj_data.items():
+                    if field_name in ["__implements"]:
+                        continue
+                    elif field_data["type"].startswith(tuple(GRAPHQL_BUILTINS)):
+                        field = field_data["type"]
+                    else:
+                        field = self.node(field_data["type"])
+                        field.add_parent(node)
+                    node.add_child(field_name, field)
+
     def __str__(self):
-        return ""
+        return f"Graph()"
+
     def __repr__(self):
-        return ""
+        return f"Graph()"
+
+    def gen_poi(self):
+        def isInteresting(s):
+            return "pass" in s
+        poi = {"functions":{},"nodes":[],"fields":{}}
+        # interesting function names
+        for node in self.schema.values():
+            print(node.name)
+            for name in node.children:
+                if isInteresting(name):
+                    arr = poi["functions"].get(node.name,[])
+                    arr.append(name)
+                    poi["functions"][node.name] = arr
+        # interesting object names
+        for name in self.nodes:
+            if isInteresting(name):
+                poi["nodes"].append(name)
+        # interesting field names
+        for node in self.nodes.values():
+            for field in node.children:
+                if isInteresting(field):
+                    arr = poi["fields"].get(node.name,[])
+                    arr.append(field)
+                    poi["fields"][node.name] = arr
+        return poi
+    
+    def gen_matrix(self):
+        keys = {name:idx for idx,name in enumerate(self.nodes)}
+        length = len(keys)
+        matrix = [[0]*length]*length
+        for node in self.nodes.values():
+            row = keys[node.name]
+            for field in node.children.values():
+                if isinstance(field,str):
+                    # must be a scalar
+                    continue
+                matrix[row][keys[field.name]] = 1
+        return matrix
+            
+
 class Node:
-    def __init__(self,name,ntype='',inputs=None,children=None,parents=None,raw=None):
+    def __init__(
+        self, name, ntype="", inputs=None, children=None, parents=None, raw=None
+    ):
         self.name = name
         self.ntype = ntype or "Object"
         self.inputs = inputs or ...
         self.children = children or {}
         self.parents = parents or {}
         self.raw = raw or {}
-    def add_child(self,field_name,child):
+
+    def add_child(self, field_name, child):
         self.children[field_name] = child
-    def add_parent(self,parent):
+
+    def add_parent(self, parent):
         self.parents[parent.name] = parent
+
     def __str__(self):
         return f"{self.ntype}(name={self.name})"
+
     def __repr__(self):
         return f"{self.ntype}(name={self.name})"
+
     def __hash__(self):
-        return hash((self.name,self.ntype))
-    def __eq__(self,other):
-        return isinstance(other,Node) and (self.name,self.ntype) == (other.name,self.ntype)
-    def __ne__(self,other):
+        return hash((self.name, self.ntype))
+
+    def __eq__(self, other):
+        return isinstance(other, Node) and (
+            (self.name, self.ntype)
+            == (
+                other.name,
+                self.ntype,
+            )
+        )
+
+    def __ne__(self, other):
         return not (self == other)
 
 
@@ -51,16 +142,15 @@ def generate(argument, fpath="cycles.txt", green_print=lambda s: print(s)):
     green_print("Generating POI's")
     # simplify schema
     si = simplify_introspection(argument)
-    schema = [Node(name=v["type"],ntype=k) for k,v in si["schema"].items()]
     # all nodes will have a name and their corresponding object
-    graph = Graph(data=si["type"])
-    # get high level function names and return types
-    for query in schema:
-        for func,data in si["type"].pop(query.name).items():
-            function_gqlo = Node(name=func,type="function",raw=data)
+    graph = Graph(
+        schema={
+            v["type"]: Node(name=v["type"], ntype=k) for k, v in si["schema"].items()
+        },
+        data=si["type"],
+    )
+    graph.generate()
 
-            
-            function_gqlo.add_child(nodes[data["type"]])
-            query.add_child(function_gqlo)
-    
+    report = graph.gen_poi()
+
     breakpoint()

--- a/inql/introspection.py
+++ b/inql/introspection.py
@@ -19,7 +19,7 @@ from datetime import date
 
 
 from .utils import string_join, mkdir_p, raw_request, urlopen
-from .generators import html, schema, cycles, query, tsv, poi
+from .generators import html, schema, cycles, query, tsv, poi, fastcycles
 
 try:
     # Use UTF8 On Python2 and Jython
@@ -178,6 +178,10 @@ def main():
                         help="User defined Point of Interest regex")
     parser.add_argument("--poi-streaming", dest="poi_stdout", action='store_true', default=False,
                         help="Stream points of interest to stdout")
+    parser.add_argument("--generate-fast-cycles", dest="generate_fast_cycles", action='store_true', default=False,
+                        help="Generate report on points of interest with detected sensitive fields")
+    parser.add_argument("--fast-cycles-streaming", dest="fast_cycles_stdout", action='store_true', default=False,
+                        help="Stream points of interest to stdout")
     parser.add_argument("--insecure", dest="insecure_certificate", action="store_true",
                         help="Accept any SSL/TLS certificate")
     parser.add_argument("-o", dest="output_directory", default=os.getcwd(),
@@ -328,6 +332,11 @@ def init(args, print_help=None):
                         fpath=os.path.join(host, "poi-%s-%s.txt" % (today, timestamp)),
                         regex=args.poi_regex,
                         streaming=args.poi_stdout,
+                        green_print=lambda s: print(string_join(green, s, reset)))
+        if args.generate_fast_cycles:
+            fastcycles.generate(argument,
+                        fpath=os.path.join(host, "fastcycles-%s-%s.txt" % (today, timestamp)),
+                        streaming=args.fast_cycles_stdout,
                         green_print=lambda s: print(string_join(green, s, reset)))
 
     else:

--- a/inql/introspection.py
+++ b/inql/introspection.py
@@ -174,6 +174,10 @@ def main():
                         help="Generate TSV representation of query templates. It may be useful to quickly search for vulnerable I/O.")
     parser.add_argument("--generate-poi", dest="generate_poi", action='store_true', default=False,
                         help="Generate report on points of interest with detected sensitive fields")
+    parser.add_argument("--poi-regex", dest="poi_regex", default=None, type=str,
+                        help="User defined Point of Interest regex")
+    parser.add_argument("--poi-streaming", dest="poi_stdout", action='store_true', default=False,
+                        help="Stream points of interest to stdout")
     parser.add_argument("--insecure", dest="insecure_certificate", action="store_true",
                         help="Accept any SSL/TLS certificate")
     parser.add_argument("-o", dest="output_directory", default=os.getcwd(),
@@ -322,6 +326,8 @@ def init(args, print_help=None):
         if args.generate_poi:
             poi.generate(argument,
                         fpath=os.path.join(host, "poi-%s-%s.txt" % (today, timestamp)),
+                        regex=args.poi_regex,
+                        streaming=args.poi_stdout,
                         green_print=lambda s: print(string_join(green, s, reset)))
 
     else:

--- a/inql/introspection.py
+++ b/inql/introspection.py
@@ -19,7 +19,7 @@ from datetime import date
 
 
 from .utils import string_join, mkdir_p, raw_request, urlopen
-from .generators import html, schema, cycles, query, tsv
+from .generators import html, schema, cycles, query, tsv, poi
 
 try:
     # Use UTF8 On Python2 and Jython
@@ -172,6 +172,8 @@ def main():
                         help="Some graph are too complex to generate cycles in reasonable time, stream to stdout")
     parser.add_argument("--generate-tsv", dest="generate_tsv", action='store_true', default=False,
                         help="Generate TSV representation of query templates. It may be useful to quickly search for vulnerable I/O.")
+    parser.add_argument("--generate-poi", dest="generate_poi", action='store_true', default=False,
+                        help="Generate report on points of interest with detected sensitive fields")
     parser.add_argument("--insecure", dest="insecure_certificate", action="store_true",
                         help="Accept any SSL/TLS certificate")
     parser.add_argument("-o", dest="output_directory", default=os.getcwd(),
@@ -316,6 +318,11 @@ def init(args, print_help=None):
             tsv.generate(argument,
                          fpath=os.path.join(host, "endpoint_%s.tsv"),
                          green_print=lambda s: print(string_join(green, s, reset)))
+    
+        if args.generate_poi:
+            poi.generate(argument,
+                        fpath=os.path.join(host, "poi-%s-%s.txt" % (today, timestamp)),
+                        green_print=lambda s: print(string_join(green, s, reset)))
 
     else:
         # Likely missing a required arguments


### PR DESCRIPTION
Added a points of interest reporting module that allows custom regex filter to find objects,fields, and functions of interest based on the regex matching, i.e. fields or objects that might contain usernames/passwords/api keys

Also added a gen_matrix function to be used with a fast cycle detection algorithm that doesnt get hung up on bigger schemas but sacrifices the verbosity of sub cycles that might exist within a larger cycle. 

Added cmdline args 
--generate-poi -> store true to run the poi function
--poi-regex -> user defined regex to use instead of default for poi function
--poi-streaming -> put the poi output to stdout
--generate-fast-cycles -> store true to run the fast cycle detection
--fast-cycles-streaming -> put the fsat cycle to stdout