### PR TITLE
Fix setuptools error due to non-compliant version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import re
 def version():
    version = "unknown"
    if os.path.isdir(".git"):
-      version = os.popen('git describe --tags --dirty').read().strip()[1:]
+      version = os.popen('git describe --tags --dirty --abbrev=0').read().strip()[1:]
    else:
       m = re.search('-([-_0-9a-f.]+?)$', os.getcwd())
       if m:


### PR DESCRIPTION
Now that `setuptools` seems to enforce the [PEP 440 – Version Identification and Dependency Specification](https://peps.python.org/pep-0440/) (as tested on a fresh and updated Kali 2023.1 environment), installing `inql` as a standalone tool fails due to the version number the `git describe` command outputs. 

In its current form, the version output would be `<TAG>-<COMMITS-AHEAD>-<HASH>` which is not compliant and prevents the successful completion of the `install` command, either through `python3 setup.py install` or `pip install`.

This PR adds the `--abbrev=0` parameter and value to `git describe`, which will only return the tag, without the commits ahead of master and hash, allowing the `install` command to run successfully.