### PR TITLE
Custom headers seetter

### DIFF
--- a/python/inql/extender.py
+++ b/python/inql/extender.py
@@ -22,6 +22,7 @@ from .timer.tab import TimerTab
 from .traffic_scan.scan_handler import BurpScannerCheck
 from .utils.decorators import unroll_exceptions
 from .utils.ui import ui_panel
+from .scraper.headers_scraper import CustomProxyListener
 
 DEBUG = True
 
@@ -85,6 +86,8 @@ class BurpExtenderPython(IExtensionStateListener):
             montoya.userInterface().registerHttpRequestEditorProvider(provideHttpRequestEditor)
             # Register ourselves as a custom scanner check
             callbacks.registerScannerCheck(BurpScannerCheck())
+            # Register the proxy listener 
+            montoya.proxy().registerRequestHandler(CustomProxyListener(app.scraped_headers))
 
 
             app.burp_laf = UIManager.getLookAndFeel()
@@ -105,6 +108,7 @@ class BurpExtenderPython(IExtensionStateListener):
                     ("Scanner", app.scanner_tab),
                     ("Timer", app.timer_tab),
                     ("Attacker", app.attacker_tab)
+                    # TODO add the settings here probably
                 )
             except Exception as e:
                 log.error("Exception: %s", str(e))

--- a/python/inql/globals.py
+++ b/python/inql/globals.py
@@ -55,3 +55,16 @@ class App(object):
     pass
 
 app = App()
+
+# This is the current selected session, by default the session is set to inql
+app.session_name = "InQL"
+
+# Custom Headers will be a dictionary of sessions. 
+# Each session will be a dictionary where all the domains have a list of headers
+app.custom_headers = {}
+app.custom_headers[app.session_name] = {}
+
+# Scraped Header will be a dictionary of domains with associated scraped headers 
+# TODO decide if the headeres will be stored in dicsts or lists.
+app.scraped_headers = {}
+

--- a/python/inql/scanner/customheaders.py
+++ b/python/inql/scanner/customheaders.py
@@ -1,0 +1,475 @@
+from java.awt import Color, Dimension
+from java.awt.event import WindowAdapter 
+from java.awt import BorderLayout, FlowLayout
+from javax.swing import JFrame, JTable, JScrollPane, JPopupMenu, JTabbedPane, JLabel, JButton, JPanel, JList, ListSelectionModel, JOptionPane
+from javax.swing.table import DefaultTableModel, DefaultTableCellRenderer
+
+from java.lang import Boolean
+
+# from inql.actions.executor import ExecutorAction
+
+from ..globals import app
+from ..logger import log
+
+from ..utils.ui import ui_button, ui_label, ui_panel, ui_textarea, inherits_popup_menu
+
+
+class CustomTable(DefaultTableModel):
+    """
+    Custom Table Model implementation. It is required to override the getColumnClass method
+    and enable the correct rendered for the Boolean Type (which will be redered as a checkbox)
+    """
+    def getColumnClass(self, c):
+        t = self.getValueAt(0, c)
+        if type(t) != bool:
+            return type(t)
+
+        # In case the type is bool, I need to return the real Boolean type of Java
+        x = Boolean(False)
+        return type(x)
+    
+class NonEditableModel(DefaultTableModel):
+    
+    def isCellEditable(self, row, column):
+        return False  # Make the column non-editable
+            
+
+
+class HeadersEditor(WindowAdapter):
+    """
+    Edits Tabular Properties of a given WindowAdapter
+    """
+    instances = {}
+    
+    last_location = None
+    locations = {}
+    last_size = None
+    sizes = {}
+
+    NEW_WINDOW_OFFSET = 32
+    offset = NEW_WINDOW_OFFSET
+
+    @staticmethod
+    def get_instance(text="Header Selector"):
+        """
+        Singleton Method based on the text property. It tries to generate only one 
+        header selector for each "session".
+
+        :param custom_headers: it contains the current custom headers
+        :param scraped_headers: it contains the current scraped headers 
+        :param text: getinstance key
+        :return: a new instance of HeadersEditor or a reused one.
+        """        
+
+        # Check if the instance is already present
+        if text not in HeadersEditor.instances:
+            log.debug("Creating the Property editor for session %s" % text)
+            HeadersEditor.instances[text] = \
+                HeadersEditor().__private_init__(text)
+
+            # setting the location
+            if text in HeadersEditor.locations:
+                HeadersEditor.instances[text].this.setLocation(HeadersEditor.locations[text])
+            elif HeadersEditor.last_location:
+                HeadersEditor.instances[text].this.setLocation(
+                    HeadersEditor.last_location.x+HeadersEditor.offset,
+                    HeadersEditor.last_location.y+HeadersEditor.offset
+                    )
+                HeadersEditor.offset = HeadersEditor.NEW_WINDOW_OFFSET
+            
+            HeadersEditor.last_location = HeadersEditor.instances[text].this.getLocation()
+            HeadersEditor.last_size = HeadersEditor.instances[text].this.getSize()
+
+        # In any case I have to set it visible and on top
+        HeadersEditor.instances[text].this.setVisible(True)
+        HeadersEditor.instances[text].this.setAlwaysOnTop(True)
+        HeadersEditor.instances[text].this.setAlwaysOnTop(False)
+        
+        return HeadersEditor.instances[text]
+
+    def __private_init__(self, text):
+        """Build the GUI for the header selection associate to a particular "text" 
+        which is usually associated to a HOST
+
+        Args:
+            text (str): Is the title of the panel
+            custom_headers (list): Custom headers defined by the user for that particular host
+            scraped_headers (dict): Scraped headers for that particular host
+
+        Returns:
+            _type_: _description_
+        """
+
+        self._empty = [False, "X-New-Header", "X-New-Header-Value"]
+        self._text = text
+
+        self._current_domain = None
+
+        # Create the set of custom headers associated to the session name
+        app.custom_headers[text] = {}
+        self._custom_headers = app.custom_headers[text]
+        self._scraped_headers = app.scraped_headers
+
+        # Data to store the state of the custom and scraped headers. 
+        # Inside the private data will be stored all the headers while in the
+        # Data structures we will only store the selected ones (for the custom)
+        # For each domain we will store a dictionary 
+        self._custom_private_data = {}
+   
+
+        # Table to display the Domains
+        self._build_domains_pane()
+
+        # Table to display the headers 
+        self._build_custom_headers_pane()
+        self._build_scraped_headers_pane()
+        self._build_gui_tabs()
+
+        # Adding custom headers with object boolean 
+        self._augmenting_scraped_headers_data()
+
+        return self
+        
+    def _build_domains_pane(self):
+        domain_colum = ["Domains"]
+        self._domain_table = JTable()
+        # self._domain_table.setDefaultEditor(object, None);
+        # self._domain_table.setDefaultRenderer(object, NonEditableColumnRenderer())  # Set the column renderer to non-editable
+
+        self._domain_dtm = NonEditableModel(0,0)
+        self._domain_dtm.setColumnIdentifiers(domain_colum)
+        self._domain_table.setModel(self._domain_dtm)
+        self._domain_table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+
+        self._domain_scroll_pane = JScrollPane(self._domain_table)
+        self._domain_scroll_pane.setPreferredSize(Dimension(150,200))
+        
+        self._domain_table.getSelectionModel().addListSelectionListener(lambda _: self._domain_selection_listener())
+
+        self._add_domain_button = ui_button("Add Domain", self._add_domain_listener, True)
+        self._domain_table_panel = JPanel(BorderLayout())
+        self._domain_table_panel.add(self._domain_scroll_pane, BorderLayout.CENTER)
+        self._domain_table_panel.add(self._add_domain_button, BorderLayout.SOUTH)
+
+    def _build_custom_headers_pane(self):        
+        custom_headers_columns = ["Flag", "Header", "Value"]
+        self._custom_headers_table = JTable()
+        self._custom_headers_dtm = CustomTable(0, 0)
+        self._custom_headers_dtm.setColumnIdentifiers(custom_headers_columns)
+        self._custom_headers_table.setModel(self._custom_headers_dtm)
+
+        self._custom_headers_dtm.addTableModelListener(lambda _: self._custom_headers_update())
+
+        # Create the "Add Row" button for the second table
+        self._add_custom_header = ui_button("Add Header", self._add_custom_headers_row)
+        # Create the "Remove Row" button for the second table
+        self._remove_custom_header = ui_button("Remove Headers", self._remove_custom_headers_row)
+               
+        # create the panel to hold the buttons
+        self._custom_headers_button_panel = JPanel(FlowLayout())
+        self._custom_headers_button_panel.add(self._add_custom_header)
+        self._custom_headers_button_panel.add(self._remove_custom_header)
+
+        self._custom_header_pane = JPanel(BorderLayout())
+        self._custom_header_pane.add(self._custom_headers_table, BorderLayout.CENTER)
+        self._custom_header_pane.add(self._custom_headers_button_panel, BorderLayout.SOUTH);
+
+    def _build_scraped_headers_pane(self):
+        scraped_headers_columns = ["Header", "Value"]
+        self._scraped_headers_table = JTable()
+        self._scraped_headers_dtm = CustomTable(0, 0)
+        self._scraped_headers_dtm.setColumnIdentifiers(scraped_headers_columns)
+        self._scraped_headers_table.setModel(self._scraped_headers_dtm)
+        
+        self._move_scraped_headers = ui_button("Move Headers", self._move_scraped_headers_row)
+        self._remove_scraped_headers = ui_button("Remove Headers", self._remove_scraped_headers_row)
+
+        self._scraped_headers_button_panel = JPanel(FlowLayout())
+        self._scraped_headers_button_panel.add(self._move_scraped_headers)
+        self._scraped_headers_button_panel.add(self._remove_scraped_headers)
+
+        self._scraped_header_pane = JPanel(BorderLayout())
+        self._scraped_header_pane.add(self._scraped_headers_table, BorderLayout.CENTER)
+        self._scraped_header_pane.add(self._scraped_headers_button_panel, BorderLayout.SOUTH);
+
+
+    def _build_gui_tabs(self):
+
+        self.this = JFrame(self._text)
+        self.this.setLayout(BorderLayout())
+
+        self._main_headers_panel = JTabbedPane()
+
+
+        self._custom_headers_label = JLabel("Custom Headers")
+        self._custom_headers_label.setHorizontalAlignment(JLabel.CENTER)
+        
+    
+        self._scraped_headers_label = JLabel("Scraped Headers")
+        self._scraped_headers_label.setHorizontalAlignment(JLabel.CENTER)
+        self._scraped_headers_pane = JScrollPane(self._scraped_headers_table)
+        self._scraped_headers_pane.add(self._scraped_headers_label)
+
+        self._button_pane = JPanel()
+        self._move_button = JButton("Move to Custom")
+        self._move_button.addActionListener(lambda _: self._move_scraped_headers_row())
+        self._button_pane.add(self._move_button)
+
+        self._main_headers_panel.addTab("Custom Headers", self._custom_header_pane)
+        self._main_headers_panel.addTab("Scraped Headers", self._scraped_header_pane)
+        self._main_headers_panel.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT)
+
+        self.this.addWindowListener(self)
+
+        self.this.setLocation(HeadersEditor.NEW_WINDOW_OFFSET, HeadersEditor.NEW_WINDOW_OFFSET)
+
+        
+        self.this.setLayout(BorderLayout())
+        self.this.add(self._domain_table_panel, BorderLayout.WEST)
+        self.this.add(self._main_headers_panel, BorderLayout.CENTER)
+
+        self.this.pack()
+        self.this.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE)
+        self.this.setVisible(True)
+
+    def _augmenting_custom_headers_data(self):
+        self._custom_headers_dtm.addRow(self._empty)
+        self._custom_headers_dtm.addRow(self._empty)
+        self._custom_headers_dtm.addRow(self._empty)
+    
+    def _augmenting_scraped_headers_data(self):
+        for k in self._scraped_headers.keys():
+            new_row = [k, self._scraped_headers[k]]
+            self._scraped_headers_dtm.addRow(new_row)
+
+    def _add_domain_listener(self, _):
+        name = JOptionPane.showInputDialog(self, "Enter domain name: ")
+        if(name != None and len(name)>0):
+            if name in self._custom_headers:
+                log.info("You can't add the same domain twice")
+                return
+            
+            self._domain_dtm.addRow([name])
+            self._custom_headers[name] = [] # TODO check if it should be a dict or if a list is fine
+            
+
+    def _domain_selection_listener(self):
+        log.info("Domain selection listener")
+
+        # get selected domain
+        selected_row_number = self._domain_table.getSelectedRow()
+        selected_domain = str(self._domain_dtm.getValueAt(selected_row_number, 0)).lower()
+        log.debug("Selected row: " + selected_domain)
+
+        #update the current domain
+        self._current_domain = None
+
+        # get custom domains
+        
+        self._custom_headers_dtm.setRowCount(0);
+        log.debug(self._custom_private_data.keys())
+        if selected_domain in self._custom_private_data.keys():
+            log.debug("The selected domain is in the custom private data")
+            # add the domains to the table
+            for header in self._custom_private_data[selected_domain]:
+                new_header = []
+                new_header.append(self._custom_private_data[selected_domain][header])
+                header = header.split(":")
+                for elem in header:
+                    new_header.append(elem)
+                    
+                log.debug("New header to add is: ")
+                log.debug(new_header)
+                self._custom_headers_dtm.addRow(new_header)
+
+        # get scraped domain
+        self._scraped_headers_dtm.setRowCount(0)
+        if selected_domain in self._scraped_headers.keys():
+            log.debug("Selected domain is in scraped headers")
+            for header in self._scraped_headers[selected_domain]:
+                log.debug("Scraped header to add is: " + header)
+                self._scraped_headers_dtm.addRow(header)
+
+        self._current_domain = selected_domain
+
+
+
+    def _add_custom_headers_row(self, _):
+        """
+        Add a new row the selection
+
+        :return: None
+        """
+        if(self._current_domain == None):
+            log.debug("You can't add a new line without having selected a domain")
+            return
+        self._custom_headers_dtm.addRow(self._empty)
+        self._custom_headers_update()
+
+    def _remove_custom_headers_row(self, _):
+        """
+        Remove all the selected rows from the selection
+        :return:
+        """
+        rows = self._custom_headers_table.getSelectedRows()
+        for i in range(0, len(rows)):
+            self._custom_headers_dtm.removeRow(rows[i] - i)
+        
+        self._custom_headers_update()
+    
+    def _remove_scraped_headers_row(self, _):
+        """
+        Remove all the selected rows from the selection
+        :return:
+        """
+        rows = self._scraped_headers_table.getSelectedRows()
+        for i in range(0, len(rows)):
+            self._scraped_headers_dtm.removeRow(rows[i] - i)
+        
+        # TODO add scraped header modifier
+    
+    def _move_scraped_headers_row(self, _):
+        """
+        Remove all the selected rows from the selection
+        :return:
+        """
+        rows = self._scraped_headers_table.getSelectedRows()
+        log.debug("The selected rows are:")
+        log.debug(rows)
+
+        cols = self._scraped_headers_table.getColumnCount()
+
+        for i in range(0, len(rows)):
+            row_to_move = [False]
+            for j in range(cols):
+                row_to_move.append(self._scraped_headers_dtm.getValueAt(rows[i] - i, j))
+            
+            log.debug("Adding new row: %s" % row_to_move)
+            self._custom_headers_dtm.addRow(row_to_move)
+            self._scraped_headers_dtm.removeRow(rows[i] - i)
+        self._custom_headers_update()
+
+    def windowClosing(self, _):
+        """
+        Overrides WindowAdapter method
+
+        :param evt: unused
+        :return: None
+        """
+        HeadersEditor.locations[self._text] = self.this.getLocation()
+        HeadersEditor.sizes[self._text] = self.this.getSize()
+        HeadersEditor.last_location = self.this.getLocation()
+        HeadersEditor.last_size = self.this.getSize()
+        HeadersEditor.offset = 0
+        self.this.setVisible(False)
+
+        # DEBUG
+        log.debug("Printing the headers at the moment of the custom headers widnows closing:")
+        log.debug(self._custom_headers)
+        for domain in self._custom_headers:
+            log.debug(self._custom_headers[domain])
+
+        log.debug("Custom Headers in the app")
+        log.debug(app.custom_headers)
+
+    def _custom_headers_update(self):
+        """
+        Update the data content with the updated rows
+
+        The old state, stored in self._private_data, is updated. 
+        Depending on the presence or not of the dest_data structure, 
+        the updates are stored either there or in the self._src_data
+
+        :return: None
+        """
+        if(self._current_domain == None):
+            log.debug("You can't add a new line without having selected a domain")
+            return
+        
+        del self._custom_headers[self._current_domain][:]
+        
+        nRow = self._custom_headers_dtm.getRowCount()
+        nCol = self._custom_headers_dtm.getColumnCount()
+        log.debug("Removing all the custom private data associated to this domain")
+        self._custom_private_data[self._current_domain] = {}
+        for i in range(0, nRow):
+            # Creating the new row
+            new_row = [None] * nCol
+            for j in range(0, nCol):
+                d = str(self._custom_headers_dtm.getValueAt(i, j)).lower()
+                if d == 'none' or d == '':
+                    new_row[j] = None
+                elif d == 'true' or d == 't':
+                    new_row[j] = True
+                elif d == 'false' or d == 'f':
+                    new_row[j] = False
+                else:
+                    try:
+                        new_row[j] = int(self._custom_headers_dtm.getValueAt(i, j))
+                    except ValueError:
+                        new_row[j] = self._custom_headers_dtm.getValueAt(i, j)
+            
+            idx = "%s:%s" % (new_row[1], new_row[2])
+            log.debug("The idx is: %s" % idx)
+            self._custom_private_data[self._current_domain][idx] = new_row[0]
+            log.debug("self._private_data[%s] = %s" % (new_row[1:], new_row[0]))
+            
+            # Adding the new row to the private headers to be displayed
+            if new_row[0] == True:
+                self._custom_headers[self._current_domain].append(new_row[1:])
+    
+    def _scraped_headers_update(self):
+        """
+        Update the data content with the updated rows
+
+        The old state, stored in self._private_data, is updated. 
+        Depending on the presence or not of the dest_data structure, 
+        the updates are stored either there or in the self._src_data
+
+        :return: None
+        """
+        # log.debug("Updating the model")
+        # if self._dest_data:
+        #     del self._dest_data[:]
+        # else:
+        #     del self._src_data[:]
+        
+        if(self._current_domain == None):
+            log.debug("You can't add a new line without having selected a domain")
+            return
+        
+        nRow = self._scraped_headers_dtm.getRowCount()
+        nCol = self._scraped_headers_dtm.getColumnCount()
+        for i in range(0, nRow):
+            # Creating the new row
+            new_row = [None] * nCol
+            for j in range(0, nCol):
+                d = str(self._scraped_headers_dtm.getValueAt(i, j)).lower()
+                if d == 'none' or d == '':
+                    new_row[j] = None
+                elif d == 'true' or d == 't':
+                    new_row[j] = True
+                elif d == 'false' or d == 'f':
+                    new_row[j] = False
+                else:
+                    try:
+                        new_row[j] = int(self._scraped_headers_dtm.getValueAt(i, j))
+                    except ValueError:
+                        new_row[j] = self._scraped_headers_dtm.getValueAt(i, j)
+            
+            idx = "%s:%s" % (new_row[1], new_row[2])
+            log.debug("The idx is: %s" % idx)
+            self._private_data[idx] = new_row[0]
+            log.debug("self._private_data[%s] = %s" % (new_row[1:], new_row[0]))
+            
+            # Adding the new row to the private headers to be displayed
+            if new_row[0] == True:
+                if self._dest_data:
+                    self._dest_data[new_row[1]] = new_row[2]
+                else:
+                    self._src_data[new_row[1]] = new_row[2]
+            else:
+                # remove from data in case dest_data is false
+                if self._dest_data == None:
+                    self._src_data.pop(new_row[1])
+                

--- a/python/inql/scanner/omnibar.py
+++ b/python/inql/scanner/omnibar.py
@@ -345,4 +345,4 @@ class ScannerOmnibar(ActionListener):
 
     def custom_header_button_handler(self, _):
         HeadersEditor.get_instance(app.session_name)
-        log.error("Working")
+        log.debug("Working")

--- a/python/inql/scanner/omnibar.py
+++ b/python/inql/scanner/omnibar.py
@@ -5,14 +5,19 @@ from java.awt import BorderLayout, Dimension
 from java.awt.event import ActionListener, FocusListener, KeyAdapter, KeyEvent
 from java.io import File
 from java.lang import System
-from javax.swing import Box, BoxLayout, JFileChooser, JSeparator, JTextField, SwingConstants
+from javax.swing import Box, BoxLayout, JFileChooser, JSeparator, JTextField, SwingConstants, JPanel 
+from java.awt import BorderLayout, FlowLayout
 
-from ..editors.propertyeditor import HeadersEditor, SettingsEditor
+from ..editors.propertyeditor import SettingsEditor
 from ..globals import app
 from ..logger import log
 from ..utils.decorators import single, single_with_error_handling
 from ..utils.ui import ui_button, ui_label, ui_panel, ui_textarea
 from .introspection import analyze
+
+from .customheaders import HeadersEditor
+from urlparse import urlparse
+
 
 
 class ScannerUrlField(FocusListener, KeyAdapter):
@@ -185,14 +190,22 @@ class ScannerOmnibar(ActionListener):
         label = ui_label("1. Provide URL of the GraphQL endpoint")
 
         #  1.1.1 First line, right - the main scanner button
-        self.main_button = ui_button('Build queries', self, main=True)
+        self.main_button = ui_button('Run Scanner', self, main=True)
+
+        self.custom_headers_button = ui_button('Custom Headers', self.custom_header_button_handler, main=False)
 
         first_line = ui_panel()
         first_line.add(BorderLayout.WEST, label)
-        first_line.add(BorderLayout.EAST, self.main_button)
+
+        button_pane = JPanel(FlowLayout())
+        button_pane.add(self.custom_headers_button)
+        button_pane.add(self.main_button)
+
+        first_line.add(BorderLayout.EAST, button_pane)
 
 
         #  1.2 Second line - just a single Text field for URL
+        # TODO add a dropdown menu to allow the user to specify which "session" to use
         self.url_field  = ScannerUrlField(self)
 
         url_panel = ui_panel(10)
@@ -267,9 +280,20 @@ class ScannerOmnibar(ActionListener):
             raise Exception("URL not provided")
 
         try:
-            analyze(self.url, self.file)
-        except:
+            log.debug("URL to be scanned: %s" % self.url)
+
+            domain = urlparse(self.url).netloc
+            log.debug("The domain is: %s" % domain)
+            
+            if domain in app.custom_headers[app.session_name]:
+                log.debug("The URL has some custom headers set")
+                analyze(self.url, self.file, headers=app.custom_headers[app.session_name][domain])
+            else:
+                log.debug("The URL has not set any custom headers, setting headers=none")
+                analyze(self.url, self.file)
+        except Exception as e:
             # analyze() is running in a separate thread and doing it's own error handling, don't raise exceptions here
+            log.error(e)
             log.error("File couldn't be analyzed properly.")
 
     @single
@@ -279,6 +303,7 @@ class ScannerOmnibar(ActionListener):
         log.debug("Received introspection analysis request from context menu.")
 
         self.url = url
+        # self.file = None
         self.file = ''
 
         try:
@@ -317,3 +342,7 @@ class ScannerOmnibar(ActionListener):
     def file(self, filename):
         log.debug("Set selected file to '%s'", filename)
         self.file_field.value = filename
+
+    def custom_header_button_handler(self, _):
+        HeadersEditor.get_instance(app.session_name)
+        log.error("Working")

--- a/python/inql/scraper/headers_scraper.py
+++ b/python/inql/scraper/headers_scraper.py
@@ -1,0 +1,66 @@
+from burp.api.montoya.proxy.http import ProxyRequestHandler, ProxyRequestReceivedAction, ProxyRequestToBeSentAction
+
+from urlparse import urlparse
+from threading import Lock
+
+from ..globals import app
+from ..logger import log
+
+class CustomProxyListener(ProxyRequestHandler):
+    """
+    This class implements a listener for the burp proxy. Every request that the proxy
+    intercepts will be analyzed and its headers will be stored.
+    """
+
+    def __init__(self, scraped_headers):
+        log.debug("Initializing the proxy listener for scraping headers")
+        
+        self._scraped_headers = scraped_headers
+
+        # burp will call the processProxyMessage concurrently thus the scraped headers 
+        # needs to be protected by a lock
+        self._lock = Lock()
+
+
+    def handleRequestReceived(self, interceptedRequest):
+        """
+        This method is invoked before an HTTP request is received by the Proxy.
+        Can modify the request.
+        Can modify the annotations.
+        Can control whether the request should be intercepted and displayed to the user for manual review or modification.
+        Can drop the request.
+        """
+
+        # get the domain of the request
+        domain = urlparse(interceptedRequest.url()).netloc
+        log.debug("Domain: %s" % domain)
+
+        if domain not in self._scraped_headers:
+            self._scraped_headers[domain] = {}
+        
+        # get the headers
+        headers = interceptedRequest.headers()
+        log.debug("Headers:")
+        log.debug(headers)
+
+        log.debug("All the headers one by one: ")
+        for h in headers:
+            log.debug("Header is -> %s: %s" % (h.name(), h.value()))
+
+            # removing connection header and host
+            if h.name() == "Connection" or h.name() == "Host": 
+                continue
+
+            if h.value() == None or len(h.value()) <=0:
+                continue
+
+            self._scraped_headers[domain][h.name().encode('utf-8')] = h.value().encode('utf-8')
+
+        log.debug(self._scraped_headers[domain])
+
+        # continue with the request
+        return ProxyRequestReceivedAction.intercept(interceptedRequest.withDefaultHeaders())
+    
+
+    def handleRequestToBeSent(self, interceptedRequest):
+        return ProxyRequestToBeSentAction.continueWith(interceptedRequest.withDefaultHeaders())


### PR DESCRIPTION
This PR partially addressed issue #100 and should be considered a substitution for PR #87. 

Custom headers are now settable through a button next to the "run scan" in the InQL user interface. That button will open a multipane window with the list of domains on the left and the associated custom headers (and scraped headers) on the right. From there it is possible to add new domains and, for each domain, manage custom and scraped headers. 
 
 