### PR TITLE
v6.0 + Improved Highlighting (#151)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 
 dependencies {
     implementation 'net.portswigger.burp.extender:burp-extender-api:2.3'
-    implementation 'net.portswigger.burp.extensions:montoya-api:1.0.0'
+    implementation 'net.portswigger.burp.extensions:montoya-api:2023.5'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
     implementation 'org.apache.commons:commons-text:1.11.0'

--- a/src/main/kotlin/inql/graphql/formatting/Style.kt
+++ b/src/main/kotlin/inql/graphql/formatting/Style.kt
@@ -1,166 +1,98 @@
 package inql.graphql.formatting
 
-import burp.Burp
 import burp.api.montoya.ui.Theme
+import java.awt.Color
 
-class Style {
-    companion object {
-        const val CLASS_STRING = "string"
-        const val CLASS_NUMBER = "number"
-        const val CLASS_COMMENT = "comment"
-        const val CLASS_SYMBOL = "symbol"
-        const val CLASS_FIELD = "field"
-        const val CLASS_TYPE = "type"
-        const val CLASS_ARGUMENT = "argument"
-        const val CLASS_KEYWORD = "keyword"
-        const val CLASS_FRAGMENT = "fragment"
-        const val CLASS_VALUE = "value"
-        const val CLASS_OBJECT = "object"
-        const val CLASS_VARIABLE = "variable"
-        const val CLASS_OPNAME = "opName"
-        const val CLASS_OPERATION = "operation"
-        const val CLASS_ALIAS = "alias"
-        const val CLASS_DIRECTIVE = "directive"
+object Style {
+    public enum class StyleClass {
+        STRING,
+        NUMBER,
+        COMMENT,
+        SYMBOL,
+        FIELD,
+        TYPE,
+        ARGUMENT,
+        KEYWORD,
+        FRAGMENT,
+        VALUE,
+        OBJECT,
+        VARIABLE,
+        OPNAME,
+        OPERATION,
+        ALIAS,
+        DIRECTIVE,
+        NONE
+    }
 
-        val CLASSES = listOf(
-            CLASS_STRING,
-            CLASS_NUMBER,
-            CLASS_COMMENT,
-            CLASS_SYMBOL,
-            CLASS_FIELD,
-            CLASS_TYPE,
-            CLASS_ARGUMENT,
-            CLASS_KEYWORD,
-            CLASS_FRAGMENT,
-            CLASS_VALUE,
-            CLASS_OBJECT,
-            CLASS_VARIABLE,
-            CLASS_OPNAME,
-            CLASS_OPERATION,
-            CLASS_ALIAS,
-            CLASS_DIRECTIVE,
-        )
-
-        fun getClass(t: Token): String {
-            return when (t.type) {
-                Token.Type.STRING -> CLASS_STRING
-                Token.Type.NUMBER -> CLASS_NUMBER
-                Token.Type.COMMENT -> CLASS_COMMENT
-                Token.Type.PUNCTUATOR -> CLASS_SYMBOL
-                Token.Type.EMPTY -> ""
-                Token.Type.NAME -> {
-                    when (t.subtype) {
-                        Token.Subtype.FIELD_NAME -> CLASS_FIELD
-                        Token.Subtype.TYPE -> CLASS_TYPE
-                        Token.Subtype.ARGUMENT_NAME -> CLASS_ARGUMENT
-                        Token.Subtype.KEYWORD -> CLASS_KEYWORD
-                        Token.Subtype.FRAGMENT_NAME -> CLASS_FRAGMENT
-                        Token.Subtype.VALUE -> CLASS_VALUE
-                        Token.Subtype.OBJECT_NAME -> CLASS_OBJECT
-                        Token.Subtype.VARIABLE_NAME -> CLASS_VARIABLE
-                        Token.Subtype.OPERATION_NAME -> CLASS_OPNAME
-                        Token.Subtype.OPERATION_TYPE -> CLASS_OPERATION
-                        Token.Subtype.ALIAS_NAME -> CLASS_ALIAS
-                        Token.Subtype.DIRECTIVE_NAME -> CLASS_DIRECTIVE
-                        Token.Subtype.NONE -> ""
-                    }
+    fun getClass(t: Token): StyleClass {
+        return when (t.type) {
+            Token.Type.STRING -> StyleClass.STRING
+            Token.Type.NUMBER -> StyleClass.NUMBER
+            Token.Type.COMMENT -> StyleClass.COMMENT
+            Token.Type.PUNCTUATOR -> StyleClass.SYMBOL
+            Token.Type.EMPTY -> StyleClass.NONE
+            Token.Type.NAME -> {
+                when (t.subtype) {
+                    Token.Subtype.FIELD_NAME -> StyleClass.FIELD
+                    Token.Subtype.TYPE -> StyleClass.TYPE
+                    Token.Subtype.ARGUMENT_NAME -> StyleClass.ARGUMENT
+                    Token.Subtype.KEYWORD -> StyleClass.KEYWORD
+                    Token.Subtype.FRAGMENT_NAME -> StyleClass.FRAGMENT
+                    Token.Subtype.VALUE -> StyleClass.VALUE
+                    Token.Subtype.OBJECT_NAME -> StyleClass.OBJECT
+                    Token.Subtype.VARIABLE_NAME -> StyleClass.VARIABLE
+                    Token.Subtype.OPERATION_NAME -> StyleClass.OPNAME
+                    Token.Subtype.OPERATION_TYPE -> StyleClass.OPERATION
+                    Token.Subtype.ALIAS_NAME -> StyleClass.ALIAS
+                    Token.Subtype.DIRECTIVE_NAME -> StyleClass.DIRECTIVE
+                    Token.Subtype.NONE -> StyleClass.NONE
                 }
             }
         }
-
-        val darkThemeStyle = Style().setColors(
-            mapOf(
-                "string" to "#92c563",
-                "number" to "#f99b56",
-                "comment" to "#C0C0C0",
-                "symbol" to "",
-                "field" to "#e9bf63",
-                "type" to "#75b5df",
-                "argument" to "#90EE90",
-                "keyword" to "white",
-                "fragment" to "#FF8C00",
-                "value" to "#f99b56",
-                "object" to "#e9bf63",
-                "variable" to "#f792da",
-                "opName" to "#FF8C00",
-                "operation" to "white",
-                "alias" to "#24d6c7",
-                "directive" to "#FFEF9F",
-            ),
-        )
-
-        val lightThemeStyle = Style().setColors(
-            mapOf(
-                "string" to "#1b8d1a",
-                "number" to "#1c1cff",
-                "comment" to "#C0C0C0",
-                "symbol" to "",
-                "field" to "#CB9921",
-                "type" to "#209FF3",
-                "argument" to "#388E38",
-                "keyword" to "#202020",
-                "fragment" to "#FF830B",
-                "value" to "#1c1cff",
-                "object" to "#388E38",
-                "variable" to "#F34BC3",
-                "opName" to "#FF830B",
-                "operation" to "#202020",
-                "alias" to "#1CA89D",
-                "directive" to "#a5b125",
-            ),
-        )
-
-        fun getStyleCSS(): String {
-            return if (Burp.Montoya.userInterface().currentTheme() == Theme.DARK) {
-                darkThemeStyle.getCSS()
-            } else {
-                lightThemeStyle.getCSS()
-            }
-        }
     }
 
-    private val cssProperties: HashMap<String, HashMap<String, String>> =
-        HashMap<String, HashMap<String, String>>().also {
-            CLASSES.forEach { className ->
-                it[className] = HashMap()
-            }
-        }
+    private val darkAttributeSetThemeStyle = mapOf(
+        StyleClass.STRING to Color(146, 197, 99),
+        StyleClass.NUMBER to Color(249, 155, 86),
+        StyleClass.COMMENT to Color(192, 192, 192),
+        StyleClass.NONE to Color(192, 192, 192),
+        StyleClass.SYMBOL to Color(192, 192, 192),
+        StyleClass.FIELD to Color(233, 191, 99),
+        StyleClass.TYPE to Color(117, 181, 223),
+        StyleClass.ARGUMENT to Color(144, 238, 144),
+        StyleClass.KEYWORD to Color(255, 255, 255),
+        StyleClass.FRAGMENT to Color(255, 140, 0),
+        StyleClass.VALUE to Color(249, 155, 86),
+        StyleClass.OBJECT to Color(233, 191, 99),
+        StyleClass.VARIABLE to Color(247, 146, 218),
+        StyleClass.OPNAME to Color(255, 140, 0),
+        StyleClass.OPERATION to Color(255, 255, 255),
+        StyleClass.ALIAS to Color(36, 214, 199),
+        StyleClass.DIRECTIVE to Color(255, 239, 159),
+    )
 
-    fun setProperty(classname: String, property: String, value: String): Style {
-        if (!CLASSES.contains(classname)) {
-            throw Exception("Invalid class name: $classname")
-        }
+    private val lightAttributeSetThemeStyle = mapOf(
+        StyleClass.STRING to Color(27, 141, 26),
+        StyleClass.NUMBER to Color(28, 28, 255),
+        StyleClass.COMMENT to Color(192, 192, 192),
+        StyleClass.NONE to Color(192, 192, 192),
+        StyleClass.SYMBOL to Color(32,32,32),
+        StyleClass.FIELD to Color(203, 153, 33),
+        StyleClass.TYPE to Color(32, 159, 243),
+        StyleClass.ARGUMENT to Color(56, 142, 56),
+        StyleClass.KEYWORD to Color(32, 32, 32),
+        StyleClass.FRAGMENT to Color(255, 131, 11),
+        StyleClass.VALUE to Color(28, 28, 255),
+        StyleClass.OBJECT to Color(56, 142, 56),
+        StyleClass.VARIABLE to Color(243, 75, 195),
+        StyleClass.OPNAME to Color(255, 131, 11),
+        StyleClass.OPERATION to Color(32, 32, 32),
+        StyleClass.ALIAS to Color(28, 168, 157),
+        StyleClass.DIRECTIVE to Color(165, 177, 37),
+    )
 
-        if (Regex("[^a-z-]]").matches(property)) {
-            throw Exception("Property with invalid characters: $property")
-        }
-
-        if (Regex("[^A-Za-z0-9#-]]").matches(value)) {
-            throw Exception("Value with invalid characters: $value")
-        }
-
-        cssProperties[classname]!![property.trim()] = value.trim()
-        return this
-    }
-
-    fun setColor(classname: String, color: String): Style {
-        this.setProperty(classname, "color", color)
-        return this
-    }
-
-    fun setColors(colorMap: Map<String, String>): Style {
-        colorMap.forEach {
-            this.setProperty(it.key, "color", it.value)
-        }
-        return this
-    }
-
-    fun getCSS(): String {
-        val css = StringBuilder()
-        css.appendLine("body, span, pre, code { white-space: pre; }")
-        for ((classname, properties) in this.cssProperties) {
-            css.appendLine(".$classname{ ${properties.map { (name, value) -> "$name: $value" }.joinToString("; ")} }")
-        }
-        return css.toString()
-    }
+    val STYLE_COLORS_BY_THEME = mapOf(
+        Theme.DARK to darkAttributeSetThemeStyle,
+        Theme.LIGHT to lightAttributeSetThemeStyle
+    )
 }

--- a/src/main/kotlin/inql/graphql/formatting/StyleMetadata.kt
+++ b/src/main/kotlin/inql/graphql/formatting/StyleMetadata.kt
@@ -1,0 +1,3 @@
+package inql.graphql.formatting
+
+data class StyleMetadata(val start: Int, val length: Int, val styleClass: Style.StyleClass)

--- a/src/main/kotlin/inql/graphql/formatting/Token.kt
+++ b/src/main/kotlin/inql/graphql/formatting/Token.kt
@@ -1,7 +1,5 @@
 package inql.graphql.formatting
 
-import org.apache.commons.text.StringEscapeUtils
-
 class Token(var type: Type, var text: String) {
 
     var subtype: Subtype = Subtype.NONE
@@ -35,15 +33,5 @@ class Token(var type: Type, var text: String) {
         return this.text
     }
 
-    fun asHTML(): String {
-        return """<span class="${Style.getClass(this)}">${StringEscapeUtils.escapeHtml4(this.text)}</span>"""
-    }
-
-    fun print(asHTML: Boolean): String {
-        return if (asHTML) {
-            this.asHTML()
-        } else {
-            this.toString()
-        }
-    }
+    val styleClass: Style.StyleClass get() = Style.getClass(this)
 }

--- a/src/main/kotlin/inql/scanner/scanresults/ScanResultsContentView.kt
+++ b/src/main/kotlin/inql/scanner/scanresults/ScanResultsContentView.kt
@@ -10,7 +10,6 @@ import inql.utils.getTextAreaComponent
 import java.awt.BorderLayout
 import java.awt.CardLayout
 import javax.swing.JPanel
-import javax.swing.JScrollPane
 
 class ScanResultsContentView(val view: ScanResultsView) : JPanel(CardLayout()) {
     companion object {
@@ -32,8 +31,7 @@ class ScanResultsContentView(val view: ScanResultsView) : JPanel(CardLayout()) {
         // GQLEditor card
         val gqlEditorCard = BorderPanel(0)
         gqlEditorCard.add(gqlEditor, BorderLayout.CENTER)
-        val scrollPane = JScrollPane( gqlEditorCard );
-        this.add(scrollPane, GQL_EDITOR_CARD)
+        this.add(gqlEditorCard, GQL_EDITOR_CARD)
 
         this.show(RAW_EDITOR_CARD)
     }
@@ -69,7 +67,7 @@ class ScanResultsContentView(val view: ScanResultsView) : JPanel(CardLayout()) {
     fun setContextMenuHandler(handler: SendFromInqlHandler) {
         handler.addRightClickHandler(rawEditor.getTextAreaComponent())
         handler.addKeyboardShortcutHandler(rawEditor.getTextAreaComponent())
-        handler.addRightClickHandler(gqlEditor)
-        handler.addKeyboardShortcutHandler(gqlEditor)
+        handler.addRightClickHandler(gqlEditor.textPane)
+        handler.addKeyboardShortcutHandler(gqlEditor.textPane)
     }
 }

--- a/src/main/kotlin/inql/scanner/scanresults/ScanResultsTreeNode.kt
+++ b/src/main/kotlin/inql/scanner/scanresults/ScanResultsTreeNode.kt
@@ -9,14 +9,19 @@ import inql.scanner.ScanResult
 import inql.utils.JsonPrettifier
 import javax.swing.tree.DefaultMutableTreeNode
 
-open class TreeNodeWithCustomLabel(val label: String, obj: Any?) : DefaultMutableTreeNode(obj) {
+open class TreeNodeWithCustomLabel(val label: String, obj: Any?, val forceDirectory: Boolean = false) : DefaultMutableTreeNode(obj) {
     override fun toString(): String {
         return this.label
+    }
+
+    override fun isLeaf(): Boolean {
+        if (forceDirectory) return false
+        return super.isLeaf()
     }
 }
 
 class GQLElementListTreeNode(label: String, val list: List<String>, val type: GQLSchema.OperationType, val schema: GQLSchema) :
-    TreeNodeWithCustomLabel(label, null) {
+    TreeNodeWithCustomLabel(label, null, forceDirectory = true) {
     init {
         list.forEach {
             this.add(TreeNodeWithCustomLabel(it, GQLQueryElement(it, type, schema)))

--- a/src/main/kotlin/inql/scanner/scanresults/ScanResultsTreeView.kt
+++ b/src/main/kotlin/inql/scanner/scanresults/ScanResultsTreeView.kt
@@ -1,5 +1,6 @@
 package inql.scanner.scanresults
 
+import inql.Logger
 import inql.ui.BorderPanel
 import java.awt.BorderLayout
 import javax.swing.JScrollPane
@@ -58,7 +59,11 @@ class ScanResultsTreeView(val view: ScanResultsView) : BorderPanel(), TreeSelect
     }
 
     override fun valueChanged(e: TreeSelectionEvent) {
-        this.tree.repaint() // For some reason, sometimes the UI doesn't update
+        try {
+            this.tree.repaint() // For some reason, sometimes the UI doesn't update
+        } catch (e: Exception) {
+            Logger.warning("Caught exception while repainting tree")
+        }
         val node = (this.tree.lastSelectedPathComponent ?: return) as DefaultMutableTreeNode
         if (!node.isLeaf) return // We don't care about folders
         this.view.selectionChangeListener(node)

--- a/src/main/kotlin/inql/scanner/scanresults/ScanResultsView.kt
+++ b/src/main/kotlin/inql/scanner/scanresults/ScanResultsView.kt
@@ -87,11 +87,11 @@ class ScanResultsView(val scannerTab: ScannerTab) : BorderPanel(0) {
     class ScannerResultSendFromInqlHandler(val view: ScanResultsView) :
         SendFromInqlHandler(view.scannerTab.inql, false) {
         private val shouldStripComments = Config.getInstance().getBoolean("editor.send_to.strip_comments")
-        private val stripCommentsFormatter = Formatter(minimized = false, spaces = 4, stripComments = true, asHTML = false, isIntrospection = true)
+        private val stripCommentsFormatter = Formatter(minimized = false, spaces = 4, stripComments = true, isIntrospection = true)
 
         private fun stripComments(query: String): String {
             Logger.warning("STRIPPING COMMENTS")
-            return this.stripCommentsFormatter.format(query);
+            return this.stripCommentsFormatter.format(query).first;
         }
         override fun getRequest(): HttpRequest? {
             Logger.warning("VALUE: $shouldStripComments")

--- a/src/main/kotlin/inql/ui/EditableTabbedPane.kt
+++ b/src/main/kotlin/inql/ui/EditableTabbedPane.kt
@@ -10,9 +10,9 @@ class EditableTabTitle(title: String, val component: Component, val isDarkMode: 
     private val changeListeners = ArrayList<(EditableTabTitle) -> Unit>()
     private var valueBeforeChange = this.text
     private val background = if (this.isDarkMode) {
-                                    Color(61,61,60)
+                                    Color(61,60,60)
                                 } else {
-                                    Color(230, 230, 230)
+                                    Color(236, 236, 236)
                                 }
 
     // A bunch of listeners to handle tab title change (these are fired when the title has been changed, not during editing)
@@ -135,7 +135,10 @@ class EditableTabTitle(title: String, val component: Component, val isDarkMode: 
 }
 
 class EditableTab(val tabTitle: EditableTabTitle, val isDarkMode: Boolean) : BoxPanel(BoxLayout.Y_AXIS, gap = 0) {
-    val closeButton = loadSvgIcon("resources/Media/svg/close.svg", 7)?.let { JButton(it) } ?: JButton("⨉")
+    private val closeIcon = loadSvgIcon("resources/Media/svg/close.svg", 8)?.also {
+        it.colorFilter = DarkModeFilter(Color.WHITE)
+    }
+    val closeButton = if (closeIcon != null) JButton(closeIcon) else JButton("⨉")
     val closeListeners = ArrayList<(EditableTab) -> Unit>()
 
     private val cornerRadius = 10 // Adjust the corner radius as needed
@@ -182,15 +185,12 @@ class EditableTab(val tabTitle: EditableTabTitle, val isDarkMode: Boolean) : Box
     }
 
     init {
-        //this.border = BorderFactory.createEmptyBorder(0, 0, 0, 0)
-        //this.isOpaque = true
-        //this.style = "background: #eee; arc: 10; borderColor: #f63; borderWidth: 3; outlineColor: #f63; outline: error; error.borderColor: #f64"
-        //this.setBorder(BorderFactory.createMatteBorder(0, 0, 2, 0, Color(255, 102, 51)));
         this.closeButton.isOpaque = false
         this.closeButton.isContentAreaFilled = false
         this.closeButton.isBorderPainted = false
         this.closeButton.iconTextGap = 0
         this.closeButton.margin = Insets(4, 4, 0, 0)
+        this.closeButton
         this.closeButton.addActionListener {
             this.closeListeners.forEach { it(this) }
         }
@@ -198,9 +198,21 @@ class EditableTab(val tabTitle: EditableTabTitle, val isDarkMode: Boolean) : Box
         val upper = BoxPanel(BoxLayout.X_AXIS, gap = 0)
         upper.isOpaque = false
         upper.add(tabTitle)
-        upper.add(this.closeButton)
         upper.border = BorderFactory.createEmptyBorder(3, 14, 3, 14)
         add(upper)
+
+        // Add close button
+        val verticalPadding = 2
+        val closeButtonPanel = JPanel().also {
+            it.layout = BoxLayout(it, BoxLayout.Y_AXIS)
+            it.isOpaque = false
+            it.add(Box.createRigidArea(Dimension(0, verticalPadding)))
+            it.add(closeButton)
+            it.add(Box.createVerticalGlue())
+            it.border = BorderFactory.createEmptyBorder(0, 0, 0, 0)
+        }
+
+        upper.add(closeButtonPanel)
     }
 
     fun addCloseListener(listener: (EditableTab) -> Unit) {
@@ -251,30 +263,30 @@ open class EditableTabbedPane : TabbedPane() {
         }
 
         tabbedPane.apply {
-            setTabAreaInsets(Insets(0, 0, 0, 0))
-            setTabInsets(Insets(0, 4, 2, 3))
+            tabAreaInsets = Insets(0, 0, 0, 0)
+            tabInsets = Insets(0, 4, 2, 3)
             style = "tabSelectionHeight: 0"
 
             // Add "New Tab" button on the right
-            setTrailingComponent(
-                BorderPanel(-2, 0, 2, 0).apply {
-                    add(FlowPanel(FlowLayout.LEFT, 0).apply {
-                        val panel = JPanel()
+            trailingComponent = BorderPanel(-2, 0, 2, 0).apply {
+                add(FlowPanel(FlowLayout.LEFT, 0).apply {
+                    val panel = JPanel()
 
-                        val icon = loadSvgIcon("resources/Media/svg/add.svg", 17)
-                        icon?.let {
-                            panel.add(JLabel(icon))
-                        } ?: panel.add(JLabel("+"))
-                        //panel.add(JLabel("+"))
-                        panel.addMouseListener(object : MouseAdapter() {
-                            override fun mouseClicked(e: MouseEvent?) {
-                                newTab()
-                            }
-                        })
-                        add(panel)
+                    val icon = loadSvgIcon("resources/Media/svg/add.svg", 18)?.also {
+                        it.colorFilter = DarkModeFilter(Color.WHITE)
+                    }
+                    icon?.let {
+                        panel.add(JLabel(icon))
+                    } ?: panel.add(JLabel("+"))
+                    //panel.add(JLabel("+"))
+                    panel.addMouseListener(object : MouseAdapter() {
+                        override fun mouseClicked(e: MouseEvent?) {
+                            newTab()
+                        }
                     })
-                }
-            )
+                    add(panel)
+                })
+            }
         }
     }
 
@@ -287,7 +299,7 @@ open class EditableTabbedPane : TabbedPane() {
         this.insertTab(title, component, this.tabCount)
     }
 
-    fun insertTab(title: String, component: JComponent, idx: Int) {
+    private fun insertTab(title: String, component: JComponent, idx: Int) {
         val editableTitle = EditableTabTitle(title, component, this.isDarkMode())
         this.changeListeners.forEach { editableTitle.addChangeListener(it) }
         val tab = EditableTab(editableTitle, this.isDarkMode())

--- a/src/main/kotlin/inql/ui/PayloadEditor.kt
+++ b/src/main/kotlin/inql/ui/PayloadEditor.kt
@@ -64,7 +64,7 @@ class PayloadEditor private constructor(val inql: InQL, readOnly: Boolean) :
         get() = this.queryEditor.contents.toString()
         set(s) {
             runBlocking {
-                this@PayloadEditor.queryEditor.contents = ByteArray.byteArray(formatter.format(s))
+                this@PayloadEditor.queryEditor.contents = ByteArray.byteArray(formatter.format(s).first)
             }
         }
     var vars: JsonObject?

--- a/src/main/kotlin/inql/ui/StyledPayloadEditor.kt
+++ b/src/main/kotlin/inql/ui/StyledPayloadEditor.kt
@@ -22,7 +22,6 @@ import inql.utils.getTextAreaComponent
 import java.awt.BorderLayout
 import java.awt.Component
 import java.awt.Font
-import javax.swing.JScrollPane
 import javax.swing.JSplitPane
 
 class StyledPayloadEditor private constructor(val inql: InQL, readOnly: Boolean) :
@@ -90,10 +89,6 @@ class StyledPayloadEditor private constructor(val inql: InQL, readOnly: Boolean)
         this.queryEditor = GraphQLEditor(readOnly)
         val gqlEditorCard = BorderPanel(0)
         gqlEditorCard.add(queryEditor, BorderLayout.CENTER)
-        val scrollPane = JScrollPane(gqlEditorCard)
-        scrollPane.verticalScrollBar.setUnitIncrement(10);
-        scrollPane.horizontalScrollBar.setUnitIncrement(10);
-
 
         if (readOnly) {
             this.varsEditor = Burp.Montoya.userInterface().createRawEditor(EditorOptions.READ_ONLY)
@@ -102,24 +97,17 @@ class StyledPayloadEditor private constructor(val inql: InQL, readOnly: Boolean)
         }
 
         this.component =
-            JSplitPane(JSplitPane.VERTICAL_SPLIT, scrollPane, this.varsEditor.uiComponent())
+            JSplitPane(JSplitPane.VERTICAL_SPLIT, gqlEditorCard, this.varsEditor.uiComponent())
         this.component.setDividerLocation(0.5)
         this.component.resizeWeight = 0.75
         this.component.isOneTouchExpandable = true
 
         // Add context menu handler
-        this.contextMenu.addRightClickHandler(this.queryEditor)
-        this.contextMenu.addKeyboardShortcutHandler(this.queryEditor)
-    }
-
-    private fun refreshFont() {
-        // This is needed because we take the font from the varsEditor and
-        //  Burp doesn't set the correct font until the editor needs to be displayed
-        this.queryEditor.setFontInHTML(this.editorFont)
+        this.contextMenu.addRightClickHandler(this.queryEditor.textPane)
+        this.contextMenu.addKeyboardShortcutHandler(this.queryEditor.textPane)
     }
 
     override fun setRequestResponse(requestResponse: HttpRequestResponse) {
-        refreshFont()
         this.request = requestResponse.request()
         lateinit var body: JsonObject
         val json_body = requestResponse.request().bodyToString()
@@ -135,7 +123,7 @@ class StyledPayloadEditor private constructor(val inql: InQL, readOnly: Boolean)
             this.varsState.error = true
 
             // Show the message about an error:
-            this.queryEditor.text = "There was an error during JSON deserialization."
+            this.queryEditor.setPlaintext("There was an error during JSON deserialization.")
             this.vars = null
             return
         }

--- a/src/main/kotlin/inql/ui/Utils.kt
+++ b/src/main/kotlin/inql/ui/Utils.kt
@@ -5,6 +5,7 @@ import burp.api.montoya.ui.editor.EditorOptions
 import burp.api.montoya.ui.editor.HttpRequestEditor
 import burp.api.montoya.ui.editor.HttpResponseEditor
 import com.formdev.flatlaf.extras.FlatSVGIcon
+import com.formdev.flatlaf.extras.FlatSVGIcon.ColorFilter
 import com.formdev.flatlaf.extras.components.FlatStyleableComponent
 import com.formdev.flatlaf.extras.components.FlatTabbedPane
 import inql.Logger
@@ -289,6 +290,15 @@ open class MessageEditor(val readOnly: Boolean = false) : JTabbedPane() {
     }
 }
 
+/*
+    Simple SVG Color Filter that makes SVG the specified color on Dark mode
+ */
+class DarkModeFilter(darkModeColor: Color): ColorFilter() {
+    init {
+        this.setMapper { color -> if (Burp.isDarkMode()) return@setMapper darkModeColor else color }
+    }
+}
+
 fun loadSvgIcon(resourcePath: String, height: Int): FlatSVGIcon? {
     // Attempt to get the resource as a stream; if null, return null early.
     val stream: InputStream = FlatSVGIcon::class.java.classLoader.getResourceAsStream(resourcePath) ?: return null
@@ -300,6 +310,7 @@ fun loadSvgIcon(resourcePath: String, height: Int): FlatSVGIcon? {
     val scalingFactor = height.toFloat() / svgIcon.iconHeight.toFloat()
 
     // Return a new svgIcon derived with the scaling factor, or null if the original icon had a height of 0 to prevent division by zero.
+    svgIcon.colorFilter
     return if (svgIcon.iconHeight > 0) svgIcon.derive(scalingFactor) else null
 }
 
@@ -328,6 +339,7 @@ class SettingsTabButton() : JPanel() {
         icon?.let {
             val iconLabel = JLabel(it)
             clickablePart.add(iconLabel)
+            it.colorFilter = DarkModeFilter(Color.LIGHT_GRAY)
         }
 
         // Add the text label

--- a/src/main/kotlin/inql/ui/WrapEditorKit.kt
+++ b/src/main/kotlin/inql/ui/WrapEditorKit.kt
@@ -1,0 +1,47 @@
+package inql.ui
+
+import javax.swing.text.*
+
+class WrapEditorKit: StyledEditorKit() {
+    private val defaultFactory = WrapFactory()
+
+    override fun getViewFactory(): ViewFactory {
+        return defaultFactory
+    }
+
+    internal class WrapLabelView(elem: Element?) : LabelView(elem) {
+        override fun getMinimumSpan(axis: Int): Float {
+            return when (axis) {
+                X_AXIS -> 0F
+                Y_AXIS -> super.getMinimumSpan(axis)
+                else -> throw IllegalArgumentException("Invalid axis: $axis")
+            }
+        }
+    }
+
+    class WrapFactory: ViewFactory {
+        override fun create(elem: Element?): View {
+            val kind = elem!!.name
+            if (kind != null) {
+                when (kind) {
+                    AbstractDocument.ContentElementName -> {
+                        return WrapLabelView(elem)
+                    }
+                    AbstractDocument.ParagraphElementName -> {
+                        return ParagraphView(elem)
+                    }
+                    AbstractDocument.SectionElementName -> {
+                        return BoxView(elem, View.Y_AXIS)
+                    }
+                    StyleConstants.ComponentElementName -> {
+                        return ComponentView(elem)
+                    }
+                    StyleConstants.IconElementName -> {
+                        return IconView(elem)
+                    }
+                }
+            }
+            return LabelView(elem)
+        }
+    }
+}


### PR DESCRIPTION
* First Kotlin-rewritten version

* Removed references to Burp's legacy API

* Upgrade gradlew wrapper

* Bump upgraded features for compatibility with the future Gradle & Java

* Add pre-commit linters

* Fix style issues suggested by ktlint

* Add embedded GraphiQL #111

* Add GraphQL Playground and GraphQL Voyager

* Add "Send to" buttons in GraphiQL

* Refactoring build scripts to use Taskfile for parallelization

* Eject graphiql

* Eject Playground

* Eject Voyager

* Move web apps rebuilds from Gradle to Taskfile

* Enable output from the build process

* Fix a bug that reset File to null after first failure.

* Fix the argument parsing to support arguments with the whitespace

* Lower the watch interval by default

* Modify right click handlers to support configuration through InQL Settings

* Expose embedded web IDEs in the context menu

* Fixes #132

* Fixes #127

* Pull in updated GQLSpection for faster parsing (#129)

* A bunch of minor performance improvements #129

* Try introspection query from latest to earliest - Closes #134

* Optimized Taskfile

* Added node_modules to .gitignore

* Updated build.gradle

* Refactored embedded webserver, fixed CORS and Introspection cache

* Taskfile: add default task

* Implemented accurate embedded browser opening

* Implemented External Tool Webserver Lazy Loading

* Made some Chromium args dynamic based on current env

* Added missing item in context menu items list

* Improved GraphQL request detection

* Added "Save to file" action

* Fixed some warnings

* Made sendToEmbeddedToolActions a list

* Fixed getGraphQLQuery and reorganized classes in packages

* Implemented Proxy Request Highlighter

* Fixed some more minor warnings

* Injecting Profile's customheaders in requests from inql.burp

* Minor optimizations

* Fixed settings and added new features options

* Formatting is now async and cached to improve performance

* Targeting latest GQLSpection commit

* Updated GraphiQL yarn checksums

* Fixed yarn concurrency issues

* Improved params sent to external IDEs

* Added option to strip comments when sending query from Scanner Results

* Chromium: don't include args if dir not found

* Exclude Origin from Session to allow CORS fixing

* Polishing for the release

* Linked to latest GQLSpection commit

* Handle empty queries and mutations

* Removing Altair and Playground

* Updated GQLSpection to latest commit

* Fixing GraphiQL sending to repeater and intruter

* Polishing the UI

* Fixing active tab bottom border

* Adding support for darkmode

* Setting new tab title

* Upgraded dependencies

* Updated contributors

* Remove python3 linting stuff

* Fixing tab coloring bug

* Editable tabs style fixes

* Use GQLSpektion

* Rename "Attacker" tab to "Batch Queries"

* Integrated GraphQL native parsing

* Restore data from project file

* Fixed glitchy JTree UI

* Batch queries view improvements

* Add changeListener

* Fixing Batch UI

* Fixing Batch UI

* Adding POI

* Adding POI

* Adding POI

* Adding POI

* Adding Cycles Detection

* Tiny improvements

* Removing "not implemented yet" text from settings

* Comment

* Changing Scanner view sections %

* Fixing formatted editor scroll speed

* Adding information about object truncating

* Fixing exception when formating queries

* Hardcoding jar name

* adding .kotlin

* Description and others before release to 6.0

* Replacing HTML with textPane attempt

* New GraphQL Editor WIP

* Bump Montoya API lib to access new features

* Fix wrong text color

* Fix font

* Fix context menu

* Fix close button

* Fix dark mode icons

* Fix directory icon not shown

* Fix context menu

* Fix style cache

* Fix scroll speed

---------